### PR TITLE
add sudo to the kubeconfig copy command, 

### DIFF
--- a/k3s/quickstart.sh
+++ b/k3s/quickstart.sh
@@ -31,6 +31,6 @@ curl -sfL https://get.k3s.io | sh -
 # Grab the kubeconfig and copy it locally
 p_echo "copying the k3s kubeconfig to the right place"
 mkdir -p ~/.kube
-cp /etc/rancher/k3s/k3s.yaml ~/.kube/kubeconfig
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/kubeconfig
 # change the permissions os that it doesn't complain
 chmod 600 ~/.kube/kubeconfig


### PR DESCRIPTION
non-sudo fails to move the kubeconfig due to a permissions error, which causes a downstream failure in the smol_k8s_homelab.py script

```bash
failed: [localhost] (item={'Command': 'python3 /home/max/smol_k8s_homelab/smol-k8s-homelab.py --k8s k3s -f /home/max/smol_k8s_homelab/config.yml'}) => {"ansible_loop_var": "item", "changed": true, "cmd": ["python3", "/home/max/smol_k8s_homelab/smol-k8s-homelab.py", "--k8s", "k3s", "-f", "/home/max/smol_k8s_homelab/config.yml"], "delta": "0:00:03.685211", "end": "2022-08-14 17:58:22.132087", "item": {"Command": "python3 /home/max/smol_k8s_homelab/smol-k8s-homelab.py --k8s k3s -f /home/max/smol_k8s_homelab/config.yml"}, "msg": "non-zero return code", "rc": 1, "start": "2022-08-14 17:58:18.446876", "stderr": "Traceback (most recent call last):\n  File \"/home/max/smol_k8s_homelab/smol-k8s-homelab.py\", line 260, in <module>\n    main()\n  File \"/home/max/smol_k8s_homelab/smol-k8s-homelab.py\", line 202, in main\n    configure_metallb(input_variables['address_pool'])\n  File \"/home/max/smol_k8s_homelab/smol-k8s-homelab.py\", line 106, in configure_metallb\n    release.install(True)\n  File \"/home/max/smol_k8s_homelab/lib/homelabHelm.py\", line 91, in install\n    util.sub_proc(cmd)\n  File \"/home/max/smol_k8s_homelab/lib/util.py\", line 54, in sub_proc\n    raise Exception(f'\\033[0;33m {err} \\n {output} \\033[00m')\nException: \u001b[0;33m Return code not zero! Return code: None \n   error: kubernetes cluster unreachable: get \"http://localhost:8080/version\": dial tcp 127.0.0.1:8080: connect: connection refused\n   \u001b[00m", "stderr_lines": ["Traceback (most recent call last):", "  File \"/home/max/smol_k8s_homelab/smol-k8s-homelab.py\", line 260, in <module>", "    main()", "  File \"/home/max/smol_k8s_homelab/smol-k8s-homelab.py\", line 202, in main", "    configure_metallb(input_variables['address_pool'])", "  File \"/home/max/smol_k8s_homelab/smol-k8s-homelab.py\", line 106, in configure_metallb", "    release.install(True)", "  File \"/home/max/smol_k8s_homelab/lib/homelabHelm.py\", line 91, in install", "    util.sub_proc(cmd)", "  File \"/home/max/smol_k8s_homelab/lib/util.py\", line 54, in sub_proc", "    raise Exception(f'\\033[0;33m {err} \\n {output} \\033[00m')", "Exception: \u001b[0;33m Return code not zero! Return code: None ", "   error: kubernetes cluster unreachable: get \"http://localhost:8080/version\": dial tcp 127.0.0.1:8080: connect: connection refused", "   \u001b[00m"], "stdout": "
```